### PR TITLE
ADD rules to enforce strict comparaison

### DIFF
--- a/src/Rules/DontUseEqualRule.php
+++ b/src/Rules/DontUseEqualRule.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TommyTrinder\PhpstanRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Equal;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/** @implements Rule<Equal> */
+final class DontUseEqualRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Equal::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            RuleErrorBuilder::message("Don't use equal comparison (==). User strict comparison (===) instead.")->build(),
+        ];
+    }
+}

--- a/src/Rules/DontUseNotEqualRule.php
+++ b/src/Rules/DontUseNotEqualRule.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TommyTrinder\PhpstanRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\NotEqual;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/** @implements Rule<NotEqual> */
+final class DontUseNotEqualRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return NotEqual::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            RuleErrorBuilder::message("Don't use not equal comparison (!=). User strict not equal comparison (!==) instead.")->build(),
+        ];
+    }
+}

--- a/tests/Rules/DontUseEqualRuleTest.php
+++ b/tests/Rules/DontUseEqualRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TommyTrinder\PhpstanRules\Tests\Rules;
+
+use DaveLiddament\PhpstanRuleTestHelper\AbstractRuleTestCase;
+use PHPStan\Rules\Rule;
+use TommyTrinder\PhpstanRules\Rules\DontUseEqualRule;
+
+/** @extends AbstractRuleTestCase<DontUseEqualRule> */
+final class DontUseEqualRuleTest extends AbstractRuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new DontUseEqualRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->assertIssuesReported(
+            __DIR__.'/Fixtures/DontUseEqualRuleFixture.php'
+        );
+    }
+
+    protected function getErrorFormatter(): string
+    {
+        return "Don't use equal comparison (==). User strict comparison (===) instead.";
+    }
+}

--- a/tests/Rules/DontUseNotEqualRuleTest.php
+++ b/tests/Rules/DontUseNotEqualRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TommyTrinder\PhpstanRules\Tests\Rules;
+
+use DaveLiddament\PhpstanRuleTestHelper\AbstractRuleTestCase;
+use PHPStan\Rules\Rule;
+use TommyTrinder\PhpstanRules\Rules\DontUseNotEqualRule;
+
+/** @extends AbstractRuleTestCase<DontUseNotEqualRule> */
+final class DontUseNotEqualRuleTest extends AbstractRuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new DontUseNotEqualRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->assertIssuesReported(
+            __DIR__.'/Fixtures/DontUseNotEqualRuleFixture.php'
+        );
+    }
+
+    protected function getErrorFormatter(): string
+    {
+        return "Don't use not equal comparison (!=). User strict not equal comparison (!==) instead.";
+    }
+}

--- a/tests/Rules/Fixtures/DontUseEqualRuleFixture.php
+++ b/tests/Rules/Fixtures/DontUseEqualRuleFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+function comparisons(?int $number): void
+{
+    if ($number == null) { // ERROR
+        echo 'Null';
+    }
+
+    if ($number === null) {
+        echo 'Null';
+    }
+
+    if ($number == 1) { // ERROR
+        echo '1';
+    }
+
+    if ($number === 1) {
+        echo '1';
+    }
+}

--- a/tests/Rules/Fixtures/DontUseNotEqualRuleFixture.php
+++ b/tests/Rules/Fixtures/DontUseNotEqualRuleFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+function comparisons(?int $number): void
+{
+    if ($number != null) { // ERROR
+        echo 'Not null';
+    }
+
+    if ($number !== null) {
+        echo 'Not null';
+    }
+
+    if ($number != 1) { // ERROR
+        echo 'Not 1';
+    }
+
+    if ($number !== 1) {
+        echo 'Not 1';
+    }
+}


### PR DESCRIPTION
Don't allow usage of: 

- `==`
- `!=`
