### PR TITLE
FIX handling of repository find/get methods

### DIFF
--- a/tests/Rules/Fixtures/CheckNamesInRepository.php
+++ b/tests/Rules/Fixtures/CheckNamesInRepository.php
@@ -48,4 +48,25 @@ class CheckNamesInRepository extends Model
     {
         return 1;
     }
+
+    public function findModels(): iterable // OK
+    {
+        return [];
+    }
+
+    public function findModelsWrong(): ?iterable // ERROR find methods must NOT be nullable if returning an iterable
+    {
+        return [];
+    }
+
+    public function getModels(): iterable // OK
+    {
+        return [];
+    }
+
+    public function getModelsWrong(): ?iterable // ERROR get methods must NOT have nullable in return type
+    {
+        return [];
+    }
+    
 }


### PR DESCRIPTION
- Better logic for checking that get* methods don't return null.
- If find methods return iterable, they can only return iterable (and not null)
- If find methods don't return iterable, they MUST be able to return null